### PR TITLE
Added support for Lua to endwise

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -32,6 +32,11 @@ augroup endwise " {{{1
                 \ let b:endwise_addition = 'end&' |
                 \ let b:endwise_words = 'fu\%[nction],wh\%[ile],if,for,try' |
                 \ let b:endwise_syngroups = 'vimFuncKey,vimNotFunc,vimCommand'
+    autocmd FileType lua
+                \ let b:endwise_addition = '\=submatch(0)=="{" ? "}" : "end"' |
+                \ let b:endwise_words = 'function,do,then' |
+                \ let b:endwise_pattern = '^\s*\zs\%(function\|do\|then\)\>\%(.*[^.:@$]\<end\>\)\@!\|\<then\|do\ze\%(\s*|.*|\)\=\s*$' |
+                \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
 augroup END " }}}1
 
 " Maps {{{1


### PR DESCRIPTION
In Lua, from what I can tell, there are three blocks that terminate with the keyword 'end'. These are 'function', 'do, and then'.  A few examples:

```
function fizz(n)
end

if(n > 3) then
    --something
end

while(n < 3) do
    -- something
end 

do
    -- something
end
```

There are other blocks like repeat-until, but this patch provides what I think is the basic functionality. Saves me tons of typing. Let me know what you think.

Cheers,
## 

Jon
