### PR TITLE
Compatibility fix for endwise and DelimitMate

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -57,6 +57,9 @@ if maparg('<CR>','i') =~# '<C-R>=.*crend(.)<CR>\|<\%(Plug\|SID\)>.*End'
 elseif maparg('<CR>','i') =~ '<CR>'
     exe "imap <script> <C-X><CR> ".maparg('<CR>','i')."<SID>AlwaysEnd"
     exe "imap <script> <CR>      ".maparg('<CR>','i')."<SID>DiscretionaryEnd"
+elseif maparg('<CR>','i') =~ '<Plug>delimitMateCR'
+    exe "imap <C-X><CR> ".maparg('<CR>', 'i')."<Plug>AlwaysEnd"
+    exe "imap <CR> ".maparg('<CR>', 'i')."<Plug>DiscretionaryEnd"
 else
     imap <C-X><CR> <CR><Plug>AlwaysEnd
     imap <CR>      <CR><Plug>DiscretionaryEnd


### PR DESCRIPTION
Hi Tim.

This is to fix a small conflict that occurs when using endwise and DelimitMate at the same time.  DelimitMate remaps <CR> in insert mode in a way that endwise doesn't detect.
