### PR TITLE
I fixed a problem that user defined 'imap <Cr>'

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -48,11 +48,11 @@ endif
 if maparg('<CR>','i') =~# '<C-R>=.*crend(.)<CR>\|<\%(Plug\|SID\)>.*End'
   " Already mapped
 elseif maparg('<CR>','i') =~ '<CR>'
-  exe "imap <script> <C-X><CR> ".maparg('<CR>','i')."<SID>AlwaysEnd"
-  exe "imap <script> <CR>      ".maparg('<CR>','i')."<SID>DiscretionaryEnd"
+  exe "imap <script> <C-X><CR> ".eval(maparg('<CR>','i'))."<SID>AlwaysEnd"
+  exe "imap <script> <CR>      ".eval(maparg('<CR>','i'))."<SID>DiscretionaryEnd"
 elseif maparg('<CR>','i') =~ '<Plug>delimitMateCR'
-  exe "imap <C-X><CR> ".maparg('<CR>', 'i')."<Plug>AlwaysEnd"
-  exe "imap <CR> ".maparg('<CR>', 'i')."<Plug>DiscretionaryEnd"
+  exe "imap <C-X><CR> ".eval(maparg('<CR>', 'i'))."<Plug>AlwaysEnd"
+  exe "imap <CR> ".eval(maparg('<CR>', 'i'))."<Plug>DiscretionaryEnd"
 else
   imap <C-X><CR> <CR><Plug>AlwaysEnd
   imap <CR>      <CR><Plug>DiscretionaryEnd


### PR DESCRIPTION
Hi Tim,

I'm Tacahiroy one of vim-endwise user.
I found following problem and fixed it.

[$HOME/.vimrc]

``` vim
imap <expr> <Cr> pumvisible() ? "\<C-y>\<Cr>" : "\<Cr>"
```

[SAMPLE CODE]

``` ruby
## before
class PagesController < ApplicationController
  def home
    [].each do#(cursor is here and press Return)
  end
end

## after
class PagesController < ApplicationController
  def home
    # user defined mapping was inserted as string
    [].each dopumvisible() ? "\\
    " : "\
    "
  end
```

I don't know 'eval()' is best way to fix this problem, but I couldn't think other way.
Would you merge this commit if it's better/best way?

Thank you.
