### PR TITLE
Fix link in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -40,7 +40,7 @@ Self-Promotion
 
 Like endwise.vim? Follow the repository on
 [GitHub](https://github.com/tpope/vim-endwise) and vote for it on
-[vim.org](http://www.vim.org/scripts/script.php?script_id=2136).  And if
+[vim.org](http://www.vim.org/scripts/script.php?script_id=2386).  And if
 you're feeling especially charitable, follow [tpope](http://tpo.pe/) on
 [Twitter](http://twitter.com/tpope) and
 [GitHub](https://github.com/tpope).


### PR DESCRIPTION
The link to vim.org in README was pointing to "repeat.vim" script. It now points to the correct page.
