### PR TITLE
Ruby: assignments to endwise pattern don't break completion

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -19,7 +19,7 @@ augroup endwise " {{{1
   autocmd FileType ruby
         \ let b:endwise_addition = '\=submatch(0)=="{" ? "}" : "end"' |
         \ let b:endwise_words = 'module,class,def,if,unless,case,while,until,begin,do' |
-        \ let b:endwise_pattern = '^\s*\zs\%(module\|class\|def\|if\|unless\|case\|while\|until\|for\|\|begin\)\>\%(.*[^.:@$]\<end\>\)\@!\|\<do\ze\%(\s*|.*|\)\=\s*$' |
+        \ let b:endwise_pattern = '^\(.*=\)\?\s*\zs\%(module\|class\|def\|if\|unless\|case\|while\|until\|for\|\|begin\)\>\%(.*[^.:@$]\<end\>\)\@!\|\<do\ze\%(\s*|.*|\)\=\s*$' |
           \ let b:endwise_syngroups = 'rubyModule,rubyClass,rubyDefine,rubyControl,rubyConditional,rubyRepeat'
   autocmd FileType sh,zsh
         \ let b:endwise_addition = '\=submatch(0)=="if" ? "fi" : submatch(0)=="case" ? "esac" : "done"' |


### PR DESCRIPTION
Methods added before an assignment to an endwise pattern where not
completed:

``` ruby
def new_method
  # no "end" added

k = case n
  when 1 then :result_1
  when 2 then :result_2
end
```

I added `\(.*=\)\?` to the endwise pattern to match this assignment.
