### PR TITLE
Mapping: keep/forward any <Plug>\w+CR mappings

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -66,7 +66,7 @@ if !exists('g:endwise_no_mappings')
   elseif maparg('<CR>','i') =~ '<CR>'
     exe "imap <script> <C-X><CR> ".maparg('<CR>','i')."<SID>AlwaysEnd"
     exe "imap <script> <CR>      ".maparg('<CR>','i')."<SID>DiscretionaryEnd"
-  elseif maparg('<CR>','i') =~ '<Plug>delimitMateCR'
+  elseif maparg('<CR>','i') =~ '<Plug>\w\+CR'
     exe "imap <C-X><CR> ".maparg('<CR>', 'i')."<Plug>AlwaysEnd"
     exe "imap <CR> ".maparg('<CR>', 'i')."<Plug>DiscretionaryEnd"
   else


### PR DESCRIPTION
This changes the map forwarding, which has been used for
<Plug>delimitMateCR, to be more generic.

I plan to setup a <Plug>-mapping for cursorcross [1], and endwise should
keep it.

You might want to make it act on any "<Plug>..." mapping. I have kept
the `CR` suffix as some kind of safety net.

1: https://github.com/mtth/cursorcross.vim
