### PR TITLE
Add `do` to the list of Elixir keywords

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -18,8 +18,8 @@ augroup endwise " {{{1
         \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
   autocmd FileType elixir
         \ let b:endwise_addition = 'end' |
-        \ let b:endwise_words = 'case,cond,bc,lc,inlist,inbits,if,unless,try,receive,function,fn' |
-        \ let b:endwise_pattern = '^\s*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\)\>\%(.*[^:]\<end\>\)\@!' |
+        \ let b:endwise_words = 'case,cond,bc,lc,inlist,inbits,if,unless,try,receive,function,fn,do' |
+        \ let b:endwise_pattern = '^\s*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\|do\)\>\%(.*[^:]\<end\>\)\@!' |
         \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |


### PR DESCRIPTION
I'm pretty sure I'm missing something since the `do` keyword is not autocompleted with an `end` keyword.
Anyway, here's a PR, if `do` was missing due to some specific reason just ignore this.

Thanks!
