### PR TITLE
Fix a problem with the `do` Elixir keyword

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -19,7 +19,7 @@ augroup endwise " {{{1
   autocmd FileType elixir
         \ let b:endwise_addition = 'end' |
         \ let b:endwise_words = 'case,cond,bc,lc,inlist,inbits,if,unless,try,receive,function,fn,do' |
-        \ let b:endwise_pattern = '^\s*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\|do\)\>\%(.*[^:]\<end\>\)\@!' |
+        \ let b:endwise_pattern = '^.*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\|do\)\>\%(.*[^:]\<end\>\)\@!' |
         \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |


### PR DESCRIPTION
As of my last comment in #60, the `do` Elixir keyword didn't work with stuff like:

``` elixir
defmodule M do
  # no `end` here
```

Now it does; I tested this behavior also with `def func do...end`, `case [...] do...end` and some other constructs, everything seems to work and, more importantly, nothing _seems_ to be broken.
