### PR TITLE
Fix elixir support for inline do: keywords

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -19,7 +19,7 @@ augroup endwise " {{{1
   autocmd FileType elixir
         \ let b:endwise_addition = 'end' |
         \ let b:endwise_words = 'do,fn' |
-        \ let b:endwise_pattern = '.*[^.:@$]\zs\<\%(do\|fn\)\>\ze\%(.*[^.:@$]\<end\>\)\@!' |
+        \ let b:endwise_pattern = '.*[^.:@$]\zs\<\%(do\(:\)\@!\|fn\)\>\ze\%(.*[^.:@$]\<end\>\)\@!' |
         \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |


### PR DESCRIPTION
I came across an issue with Elixir again, when using inline `do:` keyword arguments:

```
for x <- 1..10, do: x|

# hit enter

for x <- 1..10, do: x
|
end
```

So we must also check that the `do` is not immediately followed by a colon (a space in between would be a syntax error, so it's not something to consider). Alternatively, we could check whether there are only whitespace (or no) characters until the end of the line, which is typically the case. This PR fixes it with a negative lookahead after `do`.
