### PR TITLE
Add Support For Octave and newer Matlab Versions

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -19,7 +19,7 @@ augroup endwise " {{{1
   autocmd FileType elixir
         \ let b:endwise_addition = 'end' |
         \ let b:endwise_words = 'do,fn' |
-        \ let b:endwise_pattern = '.*[^.:@$]\zs\<\%(do\|fn\)\>\ze\%(.*[^.:@$]\<end\>\)\@!' |
+        \ let b:endwise_pattern = '.*[^.:@$]\zs\<\%(do\(:\)\@!\|fn\)\>\ze\%(.*[^.:@$]\<end\>\)\@!' |
         \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -26,6 +26,11 @@ augroup endwise " {{{1
         \ let b:endwise_words = 'module,class,def,if,unless,case,while,until,begin,do' |
         \ let b:endwise_pattern = '^\(.*=\)\?\s*\%(private\s\+\|protected\s\+\|public\s\+\|module_function\s\+\)*\zs\%(module\|class\|def\|if\|unless\|case\|while\|until\|for\|\|begin\)\>\%(.*[^.:@$]\<end\>\)\@!\|\<do\ze\%(\s*|.*|\)\=\s*$' |
         \ let b:endwise_syngroups = 'rubyModule,rubyClass,rubyDefine,rubyControl,rubyConditional,rubyRepeat'
+  autocmd FileType crystal
+        \ let b:endwise_addition = 'end' |
+        \ let b:endwise_words = 'module,class,lib,macro,struct,union,enum,def,if,unless,ifdef,case,while,until,for,begin,do' |
+        \ let b:endwise_pattern = '^\(.*=\)\?\s*\%(private\s\+\|protected\s\+\|public\s\+\|abstract\s\+\)*\zs\%(module\|class\|lib\|macro\|struct\|union\|enum\|def\|if\|unless\|ifdef\|case\|while\|until\|for\|begin\)\>\%(.*[^.:@$]\<end\>\)\@!\|\<do\ze\%(\s*|.*|\)\=\s*$' |
+        \ let b:endwise_syngroups = 'crystalModule,crystalClass,crystalLib,crystalMacro,crystalStruct,crystalDefine,crystalConditional,crystalRepeat,crystalControl'
   autocmd FileType sh,zsh
         \ let b:endwise_addition = '\=submatch(0)=="then" ? "fi" : submatch(0)=="case" ? "esac" : "done"' |
         \ let b:endwise_words = 'then,case,do' |

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -18,7 +18,8 @@ augroup endwise " {{{1
         \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
   autocmd FileType elixir
         \ let b:endwise_addition = 'end' |
-        \ let b:endwise_words = 'do' |
+        \ let b:endwise_words = 'do,fn' |
+        \ let b:endwise_pattern = '.*[^.:@$]\zs\<\%(do\|fn\)\>\ze\%(.*[^.:@$]\<end\>\)\@!' |
         \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -16,11 +16,6 @@ augroup endwise " {{{1
         \ let b:endwise_words = 'function,do,then' |
         \ let b:endwise_pattern = '^\s*\zs\%(\%(local\s\+\)\=function\)\>\%(.*\<end\>\)\@!\|\<\%(then\|do\)\ze\s*$' |
         \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
-  autocmd FileType elixir
-        \ let b:endwise_addition = 'end' |
-        \ let b:endwise_words = 'case,cond,bc,lc,inlist,inbits,if,unless,try,receive,function,fn' |
-        \ let b:endwise_pattern = '^\s*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\)\>\%(.*[^:]\<end\>\)\@!' |
-        \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |
         \ let b:endwise_words = 'module,class,def,if,unless,case,while,until,begin,do' |

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -16,6 +16,10 @@ augroup endwise " {{{1
         \ let b:endwise_words = 'function,do,then' |
         \ let b:endwise_pattern = '^\s*\zs\%(\%(local\s\+\)\=function\)\>\%(.*\<end\>\)\@!\|\<\%(then\|do\)\ze\s*$' |
         \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
+  autocmd FileType elixir
+        \ let b:endwise_addition = 'end' |
+        \ let b:endwise_words = 'do' |
+        \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |
         \ let b:endwise_words = 'module,class,def,if,unless,case,while,until,begin,do' |

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -54,7 +54,16 @@ augroup endwise " {{{1
         \ let b:endwise_addition = 'end' |
         \ let b:endwise_words = 'function,if,for' |
         \ let b:endwise_syngroups = 'matlabStatement,matlabFunction,matlabConditional,matlabRepeat'
+  autocmd FileType * call s:abbrev()
 augroup END " }}}1
+
+function! s:abbrev()
+  if exists('g:endwise_abbreviations')
+    for word in split(get(b:, 'endwise_words', ''), ',')
+      execute 'iabbrev <buffer><script>' word word.'<CR><SID>DiscretionaryEnd<Space><C-U><BS>'
+    endfor
+  endif
+endfunction
 
 " Maps {{{1
 

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -18,8 +18,8 @@ augroup endwise " {{{1
         \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
   autocmd FileType elixir
         \ let b:endwise_addition = 'end' |
-        \ let b:endwise_words = 'case,cond,bc,lc,inlist,inbits,if,unless,try,receive,function,fn,do' |
-        \ let b:endwise_pattern = '^\s*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\|do\)\>\%(.*[^:]\<end\>\)\@!' |
+        \ let b:endwise_words = 'case,cond,bc,lc,inlist,inbits,if,unless,try,receive,function,fn' |
+        \ let b:endwise_pattern = '^\s*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\)\>\%(.*[^:]\<end\>\)\@!' |
         \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -57,8 +57,13 @@ augroup endwise " {{{1
         \ let b:endwise_syngroups = 'objcObjDef'
   autocmd FileType matlab
         \ let b:endwise_addition = 'end' |
-        \ let b:endwise_words = 'function,if,for' |
+        \ let b:endwise_words = 'function,if,for,while' |
         \ let b:endwise_syngroups = 'matlabStatement,matlabFunction,matlabConditional,matlabRepeat'
+  autocmd FileType octave
+        \ let b:endwise_addition = '\=submatch(0)=="try" ? "end_try_catch" : submatch(0)=="unwind_protect" ? "end_unwind_protect" : submatch(0)=="do" ? "until" : "end".submatch(0)' |
+        \ let b:endwise_words = 'function,if,for,parfor,while,switch,try,unwind_protect,classdef,enumeration,events,methods,properties,do' |
+        \ let b:endwise_pattern = '\%(^\s*\zs\<\%(function\|if\|for\|parfor\|while\|switch\|try\|unwind_protect\|classdef\|enumeration\|events\|methods\|properties\|do\)\ze\s*$\)' |
+        \ let b:endwise_syngroups = 'octaveBeginKeyword,octaveStatement,octaveReserved,octaveEndKeyword'
   autocmd FileType * call s:abbrev()
 augroup END " }}}1
 

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -18,8 +18,8 @@ augroup endwise " {{{1
         \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
   autocmd FileType elixir
         \ let b:endwise_addition = 'end' |
-        \ let b:endwise_words = 'case,cond,bc,lc,inlist,inbits,if,unless,try,receive,function,fn' |
-        \ let b:endwise_pattern = '^\s*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\)\>\%(.*[^:]\<end\>\)\@!' |
+        \ let b:endwise_words = 'case,cond,bc,lc,inlist,inbits,if,unless,try,receive,function,fn,do' |
+        \ let b:endwise_pattern = '^\s*\zs\%(case\|cond\|bc\|lc\|inlist\|inbits\|if\|unless\|try\|receive\|function\|fn\|do\)\>\%(.*[^:]\<end\>\)\@!' |
         \ let b:endwise_syngroups = 'elixirKeyword'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -1,6 +1,6 @@
 " Location:     plugin/endwise.vim
 " Author:       Tim Pope <http://tpo.pe/>
-" Version:      1.1
+" Version:      1.2
 " License:      Same as Vim itself.  See :help license
 " GetLatestVimScripts: 2386 1 :AutoInstall: endwise.vim
 

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -57,8 +57,8 @@ augroup endwise " {{{1
         \ let b:endwise_syngroups = 'objcObjDef'
   autocmd FileType matlab
         \ let b:endwise_addition = 'end' |
-        \ let b:endwise_words = 'function,if,for,while' |
-        \ let b:endwise_syngroups = 'matlabStatement,matlabFunction,matlabConditional,matlabRepeat'
+        \ let b:endwise_words = 'function,if,for,while,parfor,switch,try,classdef,events,methods,properties' |
+        \ let b:endwise_syngroups = 'matlabStatement,matlabFunction,matlabConditional,matlabRepeat,matlabFunc,matlabLabel,matlabExceptions,matlabOO,matlabStorageClass'
   autocmd FileType octave
         \ let b:endwise_addition = '\=submatch(0)=="try" ? "end_try_catch" : submatch(0)=="unwind_protect" ? "end_unwind_protect" : submatch(0)=="do" ? "until" : "end".submatch(0)' |
         \ let b:endwise_words = 'function,if,for,parfor,while,switch,try,unwind_protect,classdef,enumeration,events,methods,properties,do' |


### PR DESCRIPTION
Hi guys,

Matlab and Octave have become very mainstream language in Machine Learning/Scientific Research community in recent years, and so does vim-endwise in my Machine Learning department. 

Thus, I decided to contribute these codes (used to be in my ~/.vimrc) which contain support for Octave and newer versions of Matlab. I believe support for Octave/Matlab would be useful to many scientists that are using vim-endwise for their Matlab/Octave code base in researches (currently people in my department are using vim-endwise and I have to copy-paste my vim-endwise Octave-support codes in my vimrc to theirs).

Here are what this Pull Request contains:

- Improve support for newer Matlab versions (and additional Matlab clauses that are still lacking)

- New support for Octave-specific syntax

If you feel that this Pull Request has errors or problems, please don't hesitate to contact me through Github or my email at phongvcao@phongvcao.com. Thank you guys!


Best regards,


Phong Cao,
phongvcao@phongvcao.com
