### PR TITLE
Expose 'crend()' in global functions

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -74,6 +74,18 @@ function! s:abbrev()
   endif
 endfunction
 
+" Functions {{{1
+
+function! EndwiseDiscretionary()
+  return <SID>crend(0)
+endfunction
+
+function! EndwiseAlways()
+  return <SID>crend(1)
+endfunction
+
+" }}}1
+
 " Maps {{{1
 
 if maparg("<Plug>DiscretionaryEnd") == ""


### PR DESCRIPTION
This PR adds two functions that provide more programmatic access to the `crend()` function.

Rationale: I'm trying to get 'sane' behaviour when I have multiple plugins attempting to attach behaviour to `<CR>`. `endwise` and the other plugins do their best to play well together but this is not always the case (e.g. I'm currently struggling with a `neocomplete` +  `autopairs` + `endwise` issue).

If I wanted to resolve the conflicts locally / in my own way, I could have a mapping (with this PR):

```
function! SmartCR()
    return "\<CR>" . "<Other Insanity>" . "\<C-R>=EndwiseDiscretionary()\<CR>"
endfunction
imap <expr><CR> SmartCR()
```

As far as I know, there's no good way to get at the `crend()` function in that context (of course, I could be wrong -- let me know if I am!)