### PR TITLE
Fix command-line-window

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -78,6 +78,11 @@ function! s:abbrev()
   endif
 endfunction
 
+function! s:teardownMappings()
+  inoremap <buffer> <C-X><CR> <C-X><CR>
+  inoremap <buffer> <CR> <CR>
+endfunction
+
 " Functions {{{1
 
 function! EndwiseDiscretionary()
@@ -112,6 +117,7 @@ if !exists('g:endwise_no_mappings')
     imap <script> <C-X><CR> <CR><SID>AlwaysEnd
     imap <CR> <CR><Plug>DiscretionaryEnd
   endif
+  autocmd endwise CmdwinEnter * call s:teardownMappings()
 endif
 
 " }}}1


### PR DESCRIPTION
The command-line-window mode uses the FileType vim which is trigger type for endwise. This causes an error (i.e. BEEP) when the user presses `<CR>` while in insert mode in the command-line-window. It also causes problems with search and replace (substitute) as described in issue #31.

This fixes issue #31 and the annoying **BEEP**!