### PR TITLE
Support CMake scripts

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -67,6 +67,11 @@ augroup endwise " {{{1
         \ let b:endwise_addition = 'endsnippet' |
         \ let b:endwise_words = 'snippet' |
         \ let b:endwise_syngroups = 'snipSnippet,snipSnippetHeader,snipSnippetHeaderKeyword'
+  autocmd FileType cmake
+        \ let b:endwise_addition = '\=submatch(0)==#toupper(submatch(0)) ? "END".submatch(0)."()" : "end".submatch(0)."()"' |
+        \ let b:endwise_words = 'foreach,function,if,macro,while' |
+        \ let b:endwise_pattern = '\%(\<end\>.*\)\@<!\<&\>' |
+        \ let b:endwise_syngroups = 'cmakeStatement'
   autocmd FileType * call s:abbrev()
 augroup END " }}}1
 


### PR DESCRIPTION
CMake has the following end-wise pairings:

 * `foreach()` / `endforeach()`
 * `function()` / `endfunction()`
 * `if()` / `endif()`
 * `macro()` / `endmacro()`
 * `while()` / `endwhile()`

The `end` forms can take an optional argument, though the argument is ignored. This code leaves that argument empty.

CMake's commands are case-insensitive (e.g., `function()`, `Function()`, `FUNCTION()`, and `fUnCtIoN()` are all equivalent). This code will maintain the case of the opening command and prefix `END` if any only if the command is written in ALL CAPS. In all other cases (i.e., the command is written in lowercase or mixed case), `end` will be prefixed.

Examples:

```cmake
if(SOME_CONDITION)
    # ...
endif()

Function(MyFunction)
    # ...
endFunction()

WHILE(TRUE)
    # ...
ENDWHILE()
```