### PR TITLE
Adjust elixir addition to handle anonymous functions

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -17,9 +17,9 @@ augroup endwise " {{{1
         \ let b:endwise_pattern = '^\s*\zs\%(\%(local\s\+\)\=function\)\>\%(.*\<end\>\)\@!\|\<\%(then\|do\)\ze\s*$' |
         \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
   autocmd FileType elixir
-        \ let b:endwise_addition = 'end' |
+        \ let b:endwise_addition = '\=match(getline(lnum), ''.*[^.:@$]\zs\%(do\|\<fn\>.*->\)\%([^#]\|#{\)*\ze\%([^.:@#$]\<end\>\)'') > -1 ? "\<ESC>ddi" : "end"' |
         \ let b:endwise_words = 'do,fn' |
-        \ let b:endwise_pattern = '.*[^.:@$]\zs\<\%(do\(:\)\@!\|fn\)\>\ze\%(.*[^.:@$]\<end\>\)\@!' |
+        \ let b:endwise_pattern = '.*[^.:@$]\zs\<\%(do\(:\)\@!\|fn\)\>' |
         \ let b:endwise_syngroups = 'elixirBlockDefinition'
   autocmd FileType ruby
         \ let b:endwise_addition = 'end' |


### PR DESCRIPTION
I understand this solution is a little bit hacky, taking advantage of the way the `endwise_additions` are added in, so if it cannot be merged I understand. I was interested in trying to solve it either way and it was some good vimscript practice.

Commit Message:
In the case where an elixir file has a single-line anonymous function,
then other 'def <method> do' will not have the 'end' automatically
added.

Example:

```elixir
  def foo do*

  def bar do
    fn -> baz end
  end
```

If the cursor is at the * and you press enter, the 'end' will not be
added. However, if you remove the 'fn -> baz end' line, then the 'end'
will be added when pressing enter on line 10.

This solution removes the negative match for an 'end' on the same line
as a 'do' or 'fn'. Instead, the endwise_addition that was added will
check that the line:
- Has a `do` or `fn.*->`
- Does not have a "#" OR if there is a "#", it is always a part of
interpolation "#{".

If there is a commented out end, as in: `fn -> foo # end`, an end will
still be inserted.

To the best of my knowledge, this will not cause any accidental inserts.
There are cases where if a "#" is inside of a string, it will not add
the extra end. However, this is a smaller problem than the current one
where a "def foo do" does not produce an end.

@kassio as the last one to update the elixir syntax, would you mind reviewing this as well?