### PR TITLE
[Vim] Don't match 'au'

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -42,8 +42,8 @@ augroup endwise " {{{1
         \ let b:endwise_pattern = '\%(\<End\>.*\)\@<!\<&\>' |
         \ let b:endwise_syngroups = 'vbStatement,vbnetStorage,vbnetProcedure,vbnet.*Words,AspVBSStatement'
   autocmd FileType vim
-        \ let b:endwise_addition = '\=submatch(0)=="augroup" ? submatch(0) . " END" : "end" . submatch(0)' |
-        \ let b:endwise_words = 'fu,fun,func,function,wh,while,if,for,try,au,augroup' |
+        \ let b:endwise_addition = '\=submatch(0)=~"aug\\%[roup]" ? submatch(0) . " END" : "end" . submatch(0)' |
+        \ let b:endwise_words = 'fu,fun,func,function,wh,while,if,for,try,aug\%[roup]' |
         \ let b:endwise_syngroups = 'vimFuncKey,vimNotFunc,vimCommand,vimAugroupKey'
   autocmd FileType c,cpp,xdefaults,haskell
         \ let b:endwise_addition = '#endif' |


### PR DESCRIPTION
`au` is short for `autocmd`, so would expand to `endau`