### PR TITLE
Add <silent> to <CR> binding

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -114,10 +114,10 @@ if !exists('g:endwise_no_mappings')
     " Already mapped
   elseif maparg('<CR>','i') =~ '<CR>'
     exe "imap <script> <C-X><CR> ".maparg('<CR>','i')."<SID>AlwaysEnd"
-    exe "imap <script> <CR>      ".maparg('<CR>','i')."<SID>DiscretionaryEnd"
+    exe "imap <silent> <script> <CR>      ".maparg('<CR>','i')."<SID>DiscretionaryEnd"
   elseif maparg('<CR>','i') =~ '<Plug>\w\+CR'
     exe "imap <C-X><CR> ".maparg('<CR>', 'i')."<Plug>AlwaysEnd"
-    exe "imap <CR> ".maparg('<CR>', 'i')."<Plug>DiscretionaryEnd"
+    exe "imap <silent> <CR> ".maparg('<CR>', 'i')."<Plug>DiscretionaryEnd"
   else
     imap <script> <C-X><CR> <CR><SID>AlwaysEnd
     imap <CR> <CR><Plug>DiscretionaryEnd


### PR DESCRIPTION
If a user has a predefined CR binding, the endwise binding will result in CR no longer being silent. This adds silent to the endwise bindings.

I noticed that #98 already submitted a fix, my apologies for not looking before making a pull request. I do believe that the silent tags are unnecessary on every binding however. This only seems to be a problem when the user has set their own bindings. Though it probably isn't a problem and is more future proof to just put silent tags on everything like #98.