### PR TITLE
Features for latex and matlab

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -72,6 +72,11 @@ augroup endwise " {{{1
         \ let b:endwise_addition = 'endsnippet' |
         \ let b:endwise_words = 'snippet' |
         \ let b:endwise_syngroups = 'snipSnippet,snipSnippetHeader,snipSnippetHeaderKeyword'
+  autocmd FileType tex
+        \ let b:endwise_addition = '\="\\end" . matchstr(submatch(0), "{.*}")' |
+        \ let b:endwise_words = 'begin' |
+        \ let b:endwise_pattern = '\\begin{\w*}' |
+        \ let b:endwise_syngroups = 'texSection,texBeginEnd,texBeginEndName,texStatement'
   autocmd FileType * call s:abbrev()
 augroup END " }}}1
 

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -58,8 +58,8 @@ augroup endwise " {{{1
         \ let b:endwise_syngroups = 'objcObjDef'
   autocmd FileType matlab
         \ let b:endwise_addition = 'end' |
-        \ let b:endwise_words = 'function,if,for' |
-        \ let b:endwise_syngroups = 'matlabStatement,matlabFunction,matlabConditional,matlabRepeat'
+        \ let b:endwise_words = 'function,if,for,switch' |
+        \ let b:endwise_syngroups = 'matlabStatement,matlabFunction,matlabConditional,matlabRepeat,matlabLabel'
   autocmd FileType htmldjango
         \ let b:endwise_addition = '{% end& %}' |
         \ let b:endwise_words = 'autoescape,block,blocktrans,cache,comment,filter,for,if,ifchanged,ifequal,ifnotequal,language,spaceless,verbatim,with' |


### PR DESCRIPTION
In matlab, automatically add end after switch statements.

In latex, automatically add \end{*1} after \begin{*1}[*2]{*3}.