### PR TITLE
Add syntax ID names to support updated syntax file

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -15,7 +15,7 @@ augroup endwise " {{{1
         \ let b:endwise_addition = 'end' |
         \ let b:endwise_words = 'function,do,then' |
         \ let b:endwise_pattern = '^\s*\zs\%(\%(local\s\+\)\=function\)\>\%(.*\<end\>\)\@!\|\<\%(then\|do\)\ze\s*$' |
-        \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond'
+        \ let b:endwise_syngroups = 'luaFunction,luaStatement,luaCond,luaLocal,luaFuncKeyword,luaRepeat'
   autocmd FileType elixir
         \ let b:endwise_addition = 'end' |
         \ let b:endwise_words = 'do,fn' |


### PR DESCRIPTION
The updated lua syntax file provided by https://github.com/tbastos/vim-lua adds some new syntax names:

- `luaLocal`
- `luaFuncKeyword`
- `luaRepeat`

These are not currently recognized by endwise. Adding them seems to work, but I don't know if there are other implications for adding them, and it's possible there might be more cases that I haven't discovered as I've only just started using lua.

I discovered these by adding a debug statement just after line 178, which appears to be where the decision is made whether or to add the "end".