### PR TITLE
Add support for vim9script's new style functions

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -44,8 +44,8 @@ augroup endwise " {{{1
         \ let b:endwise_syngroups = 'vbStatement,vbnetStorage,vbnetProcedure,vbnet.*Words,AspVBSStatement'
   autocmd FileType vim
         \ let b:endwise_addition = '\=submatch(0)=~"aug\\%[roup]" ? submatch(0) . " END" : "end" . submatch(0)' |
-        \ let b:endwise_words = 'fu\%[nction],wh\%[ile],if,for,try,aug\%[roup]\%(\s\+\cEND\)\@!' |
-        \ let b:endwise_end_pattern = '\%(end\%(fu\%[nction]\|wh\%[hile]\|if\|for\|try\)\)\|aug\%[roup]\%(\s\+\cEND\)' |
+        \ let b:endwise_words = 'fu\%[nction],wh\%[ile],if,for,try,def,aug\%[roup]\%(\s\+\cEND\)\@!' |
+        \ let b:endwise_end_pattern = '\%(end\%(fu\%[nction]\|wh\%[hile]\|if\|for\|try\|def\)\)\|aug\%[roup]\%(\s\+\cEND\)' |
         \ let b:endwise_syngroups = 'vimFuncKey,vimNotFunc,vimCommand,vimAugroupKey,vimAugroup,vimAugroupError'
   autocmd FileType c,cpp,xdefaults,haskell
         \ let b:endwise_addition = '#endif' |


### PR DESCRIPTION
Hello there!

While toying around with my own vim plugin written in vim9script, I noticed that vim-endwise does not yet support the [new style compiled functions](https://vimhelp.org/vim9.txt.html#fast-functions).

This tiny PR adds support for the new way to define these functions, using `def`.