### PR TITLE
Add support for OCaml

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -83,6 +83,11 @@ augroup endwise " {{{1
         \ let b:endwise_addition = 'endsnippet' |
         \ let b:endwise_words = 'snippet' |
         \ let b:endwise_syngroups = 'snipSnippet,snipSnippetHeader,snipSnippetHeaderKeyword'
+  autocmd FileType ocaml
+        \ let b:endwise_addition = '\=submatch(0) =~ "do" ? "done" : submatch(0) =~ "match\\|try" ? "with" : "end"' |
+        \ let b:endwise_words = 'struct,sig,begin,object,do,match,try' |
+        \ let b:endwise_pattern = '\zs\<&\>\ze\%(.*\%(end\|done\|with\)\)\@!.*$' |
+        \ let b:endwise_syngroups = 'ocamlStruct,ocamlStructEncl,ocamlSig,ocamlSigEncl,ocamlObject,ocamlLCIdentifier,ocamlKeyword,Constant,Statement,ocamlDo,ocamlEnd,'
   autocmd FileType * call s:abbrev()
   autocmd CmdwinEnter * call s:NeutralizeMap()
   autocmd VimEnter * call s:DefineMap()

--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -84,10 +84,10 @@ augroup endwise " {{{1
         \ let b:endwise_words = 'snippet' |
         \ let b:endwise_syngroups = 'snipSnippet,snipSnippetHeader,snipSnippetHeaderKeyword'
   autocmd FileType ocaml
-        \ let b:endwise_addition = '\=submatch(0) =~ "do" ? "done" : submatch(0) =~ "match\\|try" ? "with" : "end"' |
+        \ let b:endwise_addition = '\=submatch(0) ==# "do" ? "done" : submatch(0) =~# "match\\|try" ? "with" : "end"' |
         \ let b:endwise_words = 'struct,sig,begin,object,do,match,try' |
         \ let b:endwise_pattern = '\zs\<&\>\ze\%(.*\%(end\|done\|with\)\)\@!.*$' |
-        \ let b:endwise_syngroups = 'ocamlStruct,ocamlStructEncl,ocamlSig,ocamlSigEncl,ocamlObject,ocamlLCIdentifier,ocamlKeyword,Constant,Statement,ocamlDo,ocamlEnd,'
+        \ let b:endwise_syngroups = 'ocamlStruct,ocamlStructEncl,ocamlSig,ocamlSigEncl,ocamlObject,ocamlLCIdentifier,ocamlKeyword,ocamlDo,ocamlEnd,'
   autocmd FileType * call s:abbrev()
   autocmd CmdwinEnter * call s:NeutralizeMap()
   autocmd VimEnter * call s:DefineMap()


### PR DESCRIPTION
Add support for some of OCaml's pairs:
`begin end`, `struct end`, `sig end`, `object end`, `do done`, `match with`, `try with`

`if ... then ... else` is not included:
`if then` is rarely broken up and not worth the complexity. `then else` is commonly broken up but is impossible to distinguish from `if ... then\n... ;` until after the body is typed.

`let ... = ... in` is not included because it's hard to distinguish from `let ... =`. Both are very commonly used (both with indentation) making misprediction annoying. Also, `let = in` are often on the same line while `let =` most often breaks.

There's no brackets like `[ ... ]` and `{ ... }` in the plugin, presumably because they are handled by other plugins. What about OCaml's `[| ... |]` and `{x| ... |x}` that are likely not supported by plugins handling brackets ?