### PR TITLE
Fix for vim9script enddef since Vim patch 9.1.0197

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -46,7 +46,7 @@ augroup endwise " {{{1
         \ let b:endwise_addition = '\=submatch(0)=~"aug\\%[roup]" ? submatch(0) . " END" : "end" . submatch(0)' |
         \ let b:endwise_words = 'fu\%[nction],wh\%[ile],if,for,try,def,aug\%[roup]\%(\s\+\cEND\)\@!' |
         \ let b:endwise_end_pattern = '\%(end\%(fu\%[nction]\|wh\%[hile]\|if\|for\|try\|def\)\)\|aug\%[roup]\%(\s\+\cEND\)' |
-        \ let b:endwise_syngroups = 'vimFuncKey,vimNotFunc,vimCommand,vimAugroupKey,vimAugroup,vimAugroupError'
+        \ let b:endwise_syngroups = 'vimFuncKey,vimNotFunc,vimCommand,vimAugroupKey,vimAugroup,vimAugroupError,vimDefKey'
   autocmd FileType c,cpp,xdefaults,haskell
         \ let b:endwise_addition = '#endif' |
         \ let b:endwise_words = 'if,ifdef,ifndef' |


### PR DESCRIPTION
Update syngroups for vim ft to be aware of new syn keyword, vimDefKey, added in patch 9.1.0197, see https://github.com/vim/vim/commit/35e6f4ca

Fixes #148, enddef not added for vim9script compiled functions