### PR TITLE
Fix for vim9script enddef since Vim patch 9.1.1455

### DIFF
--- a/plugin/endwise.vim
+++ b/plugin/endwise.vim
@@ -46,7 +46,7 @@ augroup endwise " {{{1
         \ let b:endwise_addition = '\=submatch(0)=~"aug\\%[roup]" ? submatch(0) . " END" : "end" . submatch(0)' |
         \ let b:endwise_words = 'fu\%[nction],wh\%[ile],if,for,try,def,aug\%[roup]\%(\s\+\cEND\)\@!' |
         \ let b:endwise_end_pattern = '\%(end\%(fu\%[nction]\|wh\%[hile]\|if\|for\|try\|def\)\)\|aug\%[roup]\%(\s\+\cEND\)' |
-        \ let b:endwise_syngroups = 'vimFuncKey,vimNotFunc,vimCommand,vimAugroupKey,vimAugroup,vimAugroupError,vimDefKey'
+        \ let b:endwise_syngroups = 'vimFuncKey,vimNotFunc,vimCommand,vimAugroupKey,vimAugroup,vimAugroupError,vimDefKey,vimDef'
   autocmd FileType c,cpp,xdefaults,haskell
         \ let b:endwise_addition = '#endif' |
         \ let b:endwise_words = 'if,ifdef,ifndef' |


### PR DESCRIPTION
Syntax file changed again, vimDefKey keyword removed, use vimDef instead

See vim/vim@35e6f4ca